### PR TITLE
Use setuptools to locate XML to read

### DIFF
--- a/opcodes/k1om.py
+++ b/opcodes/k1om.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import pkg_resources
 import xml.etree.ElementTree as ET
 import os
 
@@ -767,12 +768,13 @@ def _parse_value(value, operands, base=None):
             return int(value, base)
 
 
-def read_instruction_set(filename=os.path.join(os.path.dirname(os.path.abspath(__file__)), "k1om.xml")):
+def read_instruction_set():
     """Reads instruction set data from an XML file and returns a list of :class:`Instruction` objects
 
     :param filename: path to an XML file with instruction set data
     """
-    xml_tree = ET.parse(filename)
+    data = pkg_resources.resource_stream("opcodes", "k1om.xml")
+    xml_tree = ET.parse(data)
     xml_instruction_set = xml_tree.getroot()
     assert xml_instruction_set.tag == "InstructionSet"
     assert xml_instruction_set.attrib["name"] == "k1om"

--- a/opcodes/x86.py
+++ b/opcodes/x86.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import pkg_resources
 import xml.etree.ElementTree as ET
 import os
 
@@ -890,12 +891,13 @@ def _parse_value(value, operands, base=None):
             return int(value, base)
 
 
-def read_instruction_set(filename=os.path.join(os.path.dirname(os.path.abspath(__file__)), "x86.xml")):
+def read_instruction_set():
     """Reads instruction set data from an XML file and returns a list of :class:`Instruction` objects
 
     :param filename: path to an XML file with instruction set data
     """
-    xml_tree = ET.parse(filename)
+    data = pkg_resources.resource_stream("opcodes", "x86.xml")
+    xml_tree = ET.parse(data)
     xml_instruction_set = xml_tree.getroot()
     assert xml_instruction_set.tag == "InstructionSet"
     assert xml_instruction_set.attrib["name"] == "x86"

--- a/opcodes/x86_64.py
+++ b/opcodes/x86_64.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import pkg_resources
 import xml.etree.ElementTree as ET
 import os
 
@@ -1025,12 +1026,13 @@ def _parse_value(value, operands, base=None):
             return int(value, base)
 
 
-def read_instruction_set(filename=os.path.join(os.path.dirname(os.path.abspath(__file__)), "x86_64.xml")):
+def read_instruction_set():
     """Reads instruction set data from an XML file and returns a list of :class:`Instruction` objects
 
     :param filename: path to an XML file with instruction set data
     """
-    xml_tree = ET.parse(filename)
+    data = pkg_resources.resource_stream("opcodes", "x86_64.xml")
+    xml_tree = ET.parse(data)
     xml_instruction_set = xml_tree.getroot()
     assert xml_instruction_set.tag == "InstructionSet"
     assert xml_instruction_set.attrib["name"] == "x86-64"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 from opcodes import __version__, __author__, __email__
-from distutils.core import setup
+from setuptools import setup
 
 
 def read_text_file(path):
@@ -21,6 +21,7 @@ setup(
     packages=["opcodes"],
     package_data={"opcodes": ["x86.xml", "x86_64.xml", "k1om.xml"]},
     keywords=["assembly", "assembler", "asm", "opcodes", "x86", "x86-64", "isa", "cpu"],
+    install_requires=["setuptools"],
     requires=[],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This makes the code compatible with opcodes being packaged up as an .egg
file, which is required for supporting

It also makes setuptools a requirement for installing the package. This
should probably be documented.

This is part of making PeachPy easy to install by making the code
generation happen automatically during installation time (see
https://github.com/Maratyszcza/PeachPy/issues/38).