### PR TITLE
Migrate tests from nosetests to pytest

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2
@@ -21,10 +21,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install package
       run: |
         python -m pip install --upgrade pip
-    - name: Test with nosetests
+        python -m pip install .
+    - name: Test with pytest
       run: |
-        pip install nose
-        nosetests
+        pip install -r test/requirements.txt
+        pytest

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Assembly",
 	"Programming Language :: Python",
-	"Programming Language :: Python :: 2",
 	"Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development",

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,1 +1,1 @@
-nose
+pytest

--- a/test/test_k1om.py
+++ b/test/test_k1om.py
@@ -1,8 +1,3 @@
-import unittest
-
-
-class ReadXML(unittest.TestCase):
-    def runTest(self):
-        from opcodes.k1om import read_instruction_set
-        instruction_set = read_instruction_set()
-
+def test_read_instruction_set():
+    from opcodes.k1om import read_instruction_set
+    instruction_set = read_instruction_set()

--- a/test/test_x86.py
+++ b/test/test_x86.py
@@ -1,8 +1,3 @@
-import unittest
-
-
-class ReadXML(unittest.TestCase):
-    def runTest(self):
-        from opcodes.x86 import read_instruction_set
-        instruction_set = read_instruction_set()
-
+def test_read_instruction_set():
+    from opcodes.x86 import read_instruction_set
+    instruction_set = read_instruction_set()

--- a/test/test_x86_64.py
+++ b/test/test_x86_64.py
@@ -1,8 +1,3 @@
-import unittest
-
-
-class ReadXML(unittest.TestCase):
-    def runTest(self):
-        from opcodes.x86_64 import read_instruction_set
-        instruction_set = read_instruction_set()
-
+def test_read_instruction_set():
+    from opcodes.x86_64 import read_instruction_set
+    instruction_set = read_instruction_set()


### PR DESCRIPTION
nosetests doesn't work with Python >= 3.10