### PR TITLE
Add INT3 instructions

### DIFF
--- a/opcodes/k1om.xml
+++ b/opcodes/k1om.xml
@@ -2784,16 +2784,17 @@
   </Instruction>
   <Instruction name="INT" summary="Call to Interrupt Procedure">
     <InstructionForm gas-name="int">
-      <Operand type="3"/>
-      <Encoding>
-        <Opcode byte="CC"/>
-      </Encoding>
-    </InstructionForm>
-    <InstructionForm gas-name="int">
       <Operand type="imm8"/>
       <Encoding>
         <Opcode byte="CD"/>
         <Immediate size="1" value="#0"/>
+      </Encoding>
+    </InstructionForm>
+  </Instruction>
+  <Instruction name="INT3" summary="Interrupt 3 (debug trap)">
+    <InstructionForm gas-name="int3">
+      <Encoding>
+        <Opcode byte="CC"/>
       </Encoding>
     </InstructionForm>
   </Instruction>

--- a/opcodes/x86.xml
+++ b/opcodes/x86.xml
@@ -5560,16 +5560,17 @@
   </Instruction>
   <Instruction name="INT" summary="Call to Interrupt Procedure">
     <InstructionForm gas-name="int" go-name="INT">
-      <Operand type="3"/>
-      <Encoding>
-        <Opcode byte="CC"/>
-      </Encoding>
-    </InstructionForm>
-    <InstructionForm gas-name="int" go-name="INT">
       <Operand type="imm8"/>
       <Encoding>
         <Opcode byte="CD"/>
         <Immediate size="1" value="#0"/>
+      </Encoding>
+    </InstructionForm>
+  </Instruction>
+  <Instruction name="INT3" summary="Interrupt 3 (debug trap)">
+    <InstructionForm gas-name="int3">
+      <Encoding>
+        <Opcode byte="CC"/>
       </Encoding>
     </InstructionForm>
   </Instruction>

--- a/opcodes/x86_64.xml
+++ b/opcodes/x86_64.xml
@@ -8155,16 +8155,17 @@
   </Instruction>
   <Instruction name="INT" summary="Call to Interrupt Procedure">
     <InstructionForm gas-name="int" go-name="INT">
-      <Operand type="3"/>
-      <Encoding>
-        <Opcode byte="CC"/>
-      </Encoding>
-    </InstructionForm>
-    <InstructionForm gas-name="int" go-name="INT">
       <Operand type="imm8"/>
       <Encoding>
         <Opcode byte="CD"/>
         <Immediate size="1" value="#0"/>
+      </Encoding>
+    </InstructionForm>
+  </Instruction>
+  <Instruction name="INT3" summary="Interrupt 3 (debug trap)">
+    <InstructionForm gas-name="int3">
+      <Encoding>
+        <Opcode byte="CC"/>
       </Encoding>
     </InstructionForm>
   </Instruction>


### PR DESCRIPTION
Previously it was a specialization of `INT 3`, but behaviour is slightly different than the two-byte INT instruction and Intel manuals consider it a separate instruction