### PR TITLE
Change operand type for PREFETCHIT0/PREFETCHIT1 instructions

### DIFF
--- a/opcodes/x86_64.py
+++ b/opcodes/x86_64.py
@@ -145,6 +145,9 @@ class Operand:
         "rel32"
             A 32-bit signed offset relative to the address of instruction end.
 
+        "rel32m"
+            A 32-bit signed offset relative to the address of instruction end as a RIP-relative memory operand.
+
         "imm4"
             A 4-bit immediate value.
 

--- a/opcodes/x86_64.xsd
+++ b/opcodes/x86_64.xsd
@@ -78,6 +78,7 @@
 			<xs:enumeration value="vm64z{k}" />
 			<xs:enumeration value="rel8" />
 			<xs:enumeration value="rel32" />
+			<xs:enumeration value="rel32m" />
 			<xs:enumeration value="{er}" />
 			<xs:enumeration value="{sae}" />
 		</xs:restriction>


### PR DESCRIPTION
PREFETCHIT0/PREFETCHIT1 instructions per Intel manual accept an m8 operand. However, this m8 operand is restricted to RIP-relative address, similar to rel32, although it is encoded via Mod R/M byte rather than via immediate 32-bit relative offset. This change introduced a new rel32m operand type specifically for this instruction. Unfortunately, we can't directly use rel32, because the assembly syntax is different, e.g. offset(%rip) instead of offset in AT&T assembly.